### PR TITLE
Enable passing samesite when calling removeItem()  (Fixes #2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# HEAD
+
+## Bug Fixes
+
+-   **js:** Enable passing `samesite` when calling removeItem() (#2)
+
 # 1.0.1
 
 ## Bug Fixes
@@ -5,6 +11,7 @@
 -   **node:** Update version number after accidental publish before a pull.
 
 # 1.0.0
+
 ## Bug Fixes
 
 -   **js:** Remove `Mozilla` JS namespace from library.

--- a/README.md
+++ b/README.md
@@ -17,11 +17,11 @@ Import the library at your applications entrypoint via require, import or by usi
 Once that object is instanciated you can use the following functions:
 | Function | Notes |
 | ------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
-| `Mozilla.Cookies.setItem(name, value[, end[, path[, domain[, secure[, samesite]]]]])` | will set a cookie inside of `document.cookie` If the cookie is created it will return `true` otherwise, `false` |
-| `Mozilla.Cookies.getItem(name)` | Will return the key that you pass to the function, if not found or no argument was passed - will return null |
-| `Mozilla.removeItem(name[, path[, domain]])` | Will remove the cookie that matches the passed key. If no key is found, it will return `false` |
-| `Mozilla.Cookies.hasItem(name)` | Will return true if cookie is found that matches the passed key. If no key is found it will return `false` |
-| `Mozilla.Cookies.keys()` | Will return an array of the keys found in `document.cookie` |
+| `CookieHelper.setItem(name, value[, end[, path[, domain[, secure[, samesite]]]]])` | will set a cookie inside of `document.cookie` If the cookie is created it will return `true` otherwise, `false` |
+| `CookieHelper.getItem(name)` | Will return the key that you pass to the function, if not found or no argument was passed - will return null |
+| `CookieHelper.removeItem(name[, path[, domain]])` | Will remove the cookie that matches the passed key. If no key is found, it will return `false`. If key is found, it will set the cookie to expire immediately and then return `true` |
+| `CookieHelper.hasItem(name)` | Will return true if cookie is found that matches the passed key. If no key is found it will return `false` |
+| `CookieHelper.keys()` | Will return an array of the keys found in `document.cookie` |
 
 ## Further Doumentation
 

--- a/src/mozilla-cookie-helper.js
+++ b/src/mozilla-cookie-helper.js
@@ -69,17 +69,20 @@ var CookieHelper = {
             (!vSamesite ? '' : '; samesite=' + vSamesite);
         return true;
     },
-    removeItem: function (sKey, sPath, sDomain) {
+    removeItem: function (sKey, sPath, sDomain, bSecure, vSamesite) {
         'use strict';
         if (!this.hasItem(sKey)) {
             return false;
         }
-        document.cookie =
-            encodeURIComponent(sKey) +
-            '=; expires=Thu, 01 Jan 1970 00:00:00 GMT' +
-            (sDomain ? '; domain=' + sDomain : '') +
-            (sPath ? '; path=' + sPath : '');
-        return true;
+        return this.setItem(
+            sKey,
+            '',
+            'Thu, 01 Jan 1970 00:00:00 GMT',
+            sPath,
+            sDomain,
+            bSecure,
+            vSamesite
+        );
     },
     hasItem: function (sKey) {
         'use strict';

--- a/tests/test-cookie-helper.js
+++ b/tests/test-cookie-helper.js
@@ -52,7 +52,7 @@ describe('mozilla-cookie-helper.js', function () {
         beforeEach(clearCookies);
         afterEach(clearCookies);
 
-        it('should be called when calling Mozilla.Cookies.setItem', function () {
+        it('should be called when calling CookieHelper.setItem', function () {
             const spy = spyOn(window.CookieHelper, 'checkSameSite');
             window.CookieHelper.setItem(cookieId);
             expect(spy).toHaveBeenCalled();
@@ -140,6 +140,43 @@ describe('mozilla-cookie-helper.js', function () {
 
         it('should return true if the cookie is found in document.cookie', function () {
             expect(window.CookieHelper.removeItem(cookieId)).toBeTrue();
+        });
+
+        it('should set a cookie to expire immediately', function () {
+            spyOn(window.CookieHelper, 'setItem').and.callThrough();
+            expect(window.CookieHelper.removeItem(cookieId)).toBeTrue();
+            expect(window.CookieHelper.setItem).toHaveBeenCalledWith(
+                'test-cookie',
+                '',
+                'Thu, 01 Jan 1970 00:00:00 GMT',
+                undefined,
+                undefined,
+                undefined,
+                undefined
+            );
+        });
+
+        it('should pass optional parameters', function () {
+            spyOn(window.CookieHelper, 'setItem').and.callThrough();
+            expect(
+                window.CookieHelper.removeItem(
+                    cookieId,
+                    '/test/',
+                    'www.mozilla.org',
+                    false,
+                    'lax'
+                )
+            ).toBeTrue();
+
+            expect(window.CookieHelper.setItem).toHaveBeenCalledWith(
+                'test-cookie',
+                '',
+                'Thu, 01 Jan 1970 00:00:00 GMT',
+                '/test/',
+                'www.mozilla.org',
+                false,
+                'lax'
+            );
         });
     });
 


### PR DESCRIPTION
I did some testing in bedrock and I think we should be OK here just to include `samesite='lax'` by default when calling `removeItem()`, since all it's really doing is setting a cookie with the corresponding ID to expire immediately.

~Alex~Also fixed up a couple of typos.