### PR TITLE
Transpile package using Babel (Fixes #6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Bug Fixes
 
+-   **js:** Transpile package using Babel (#6).
 -   **js:** Enable passing `samesite` when calling removeItem() (#2)
 
 # 1.0.1

--- a/docs/README.md
+++ b/docs/README.md
@@ -3,9 +3,9 @@
 
 ### Contents
 
-- [Building the NPM package](#building-the-npm-package)
-- [Running tests](#running-tests)
-- [Publishing to NPM](#publishing-to-npm)
+-   [Building the NPM package](#building-the-npm-package)
+-   [Running tests](#running-tests)
+-   [Publishing to NPM](#publishing-to-npm)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 

--- a/package.json
+++ b/package.json
@@ -43,5 +43,9 @@
         "sinon": "^13.0.1",
         "webpack": "^5.73.0",
         "webpack-cli": "^4.9.2"
-    }
+    },
+    "browserslist": [
+        "defaults",
+        "IE 8"
+    ]
 }

--- a/src/mozilla-cookie-helper.js
+++ b/src/mozilla-cookie-helper.js
@@ -4,7 +4,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-var CookieHelper = {
+const CookieHelper = {
     getItem: function (sKey) {
         'use strict';
         if (!sKey) {
@@ -34,7 +34,7 @@ var CookieHelper = {
         ) {
             return false;
         }
-        var sExpires = '';
+        let sExpires = '';
         if (vEnd) {
             switch (vEnd.constructor) {
                 case Number:
@@ -97,7 +97,7 @@ var CookieHelper = {
     },
     keys: function () {
         'use strict';
-        var aKeys = document.cookie
+        const aKeys = document.cookie
             .replace(
                 // see issue 11338.
                 // eslint-disable-next-line no-useless-backreference
@@ -105,7 +105,7 @@ var CookieHelper = {
                 ''
             )
             .split(/\s*(?:=[^;]*)?;\s*/);
-        for (var nLen = aKeys.length, nIdx = 0; nIdx < nLen; nIdx++) {
+        for (let nLen = aKeys.length, nIdx = 0; nIdx < nLen; nIdx++) {
             aKeys[nIdx] = decodeURIComponent(aKeys[nIdx]);
         }
         return aKeys;
@@ -129,7 +129,7 @@ var CookieHelper = {
         try {
             // Create cookie
             document.cookie = 'cookietest=1; SameSite=Lax';
-            var ret = document.cookie.indexOf('cookietest=') !== -1;
+            const ret = document.cookie.indexOf('cookietest=') !== -1;
             // Delete cookie
             document.cookie =
                 'cookietest=1; SameSite=Lax; expires=Thu, 01-Jan-1970 00:00:01 GMT';

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -14,6 +14,29 @@ module.exports = {
             type: 'umd'
         }
     },
+    module: {
+        rules: [
+            {
+                test: /\.js$/,
+                exclude: /node_modules/,
+                use: {
+                    loader: 'babel-loader',
+                    options: {
+                        presets: [
+                            [
+                                '@babel/preset-env',
+                                {
+                                    targets: {
+                                        ie: '10'
+                                    }
+                                }
+                            ]
+                        ]
+                    }
+                }
+            }
+        ]
+    },
     performance: {
         hints: 'warning'
     },

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -22,16 +22,7 @@ module.exports = {
                 use: {
                     loader: 'babel-loader',
                     options: {
-                        presets: [
-                            [
-                                '@babel/preset-env',
-                                {
-                                    targets: {
-                                        ie: '10'
-                                    }
-                                }
-                            ]
-                        ]
+                        presets: ['@babel/preset-env']
                     }
                 }
             }


### PR DESCRIPTION
This fixes an issue in bedrock with the generated UMD code throwing a syntax error in old browsers. It looks like we're going to need to use Babel after all, as Webpack includes some arrow function in the generated UMD code by default.

I did some bedrock testing locally using the compiled output this PR creates, and as long as we stick to things like arrow functions and `const` / `let`, then the transpiled output should work fine in old IE browsers.