### PR TITLE
Bump package to v1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# HEAD
+# 1.1.0
 
 ## Bug Fixes
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@mozmeao/cookie-helper",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "@mozmeao/cookie-helper",
-            "version": "1.0.0",
+            "version": "1.1.0",
             "license": "MPL-2.0",
             "devDependencies": {
                 "@babel/core": "^7.17.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@mozmeao/cookie-helper",
-    "version": "1.0.1",
+    "version": "1.1.0",
     "description": "A complete cookies reader/writer framework with full unicode support.",
     "main": "index.js",
     "scripts": {


### PR DESCRIPTION
Although not strictly required, it would be nice to get https://github.com/mozmeao/cookie-helper/pull/9 into this release first if we have time to review?